### PR TITLE
EntityAjaxType: use correct ChoiceLoader & always use iterable data

### DIFF
--- a/Form/ChoiceLoader/AjaxDoctrineChoiceLoader.php
+++ b/Form/ChoiceLoader/AjaxDoctrineChoiceLoader.php
@@ -3,7 +3,7 @@
 namespace whatwedo\CrudBundle\Form\ChoiceLoader;
 
 use Doctrine\Common\Collections\Collection;
-use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader;
+use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLoader;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -16,11 +16,11 @@ class AjaxDoctrineChoiceLoader implements ChoiceLoaderInterface
     private $selected = [];
 
     /**
-     * @var DoctrineChoiceLoader
+     * @var ChoiceLoader
      */
     private $doctrineChoiceLoader;
 
-    public function __construct(DoctrineChoiceLoader $doctrineChoiceLoader)
+    public function __construct(ChoiceLoader $doctrineChoiceLoader)
     {
         $this->doctrineChoiceLoader = $doctrineChoiceLoader;
     }

--- a/Form/ChoiceLoader/AjaxDoctrineChoiceLoader.php
+++ b/Form/ChoiceLoader/AjaxDoctrineChoiceLoader.php
@@ -28,7 +28,11 @@ class AjaxDoctrineChoiceLoader implements ChoiceLoaderInterface
     public function onFormPostSetData(FormEvent $event)
     {
         $data = $event->getData();
-        $this->selected = is_iterable($data) ? $data : [$data];
+        if($data){
+            $this->selected = is_iterable($data) ? $data : [$data];
+        }else{
+            $this->selected = [];
+        }
     }
 
     public function loadChoiceList($value = null)

--- a/Form/Type/EntityAjaxType.php
+++ b/Form/Type/EntityAjaxType.php
@@ -27,7 +27,6 @@
 
 namespace whatwedo\CrudBundle\Form\Type;
 
-use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,6 +37,7 @@ use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
 use whatwedo\CrudBundle\Form\ChoiceLoader\AjaxDoctrineChoiceLoader;
+use Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLoader;
 
 class EntityAjaxType extends AbstractType
 {
@@ -71,7 +71,7 @@ class EntityAjaxType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefault('choice_loader', function (Options $options, DoctrineChoiceLoader $doctrineChoiceLoader) {
+        $resolver->setDefault('choice_loader', function (Options $options, ChoiceLoader $doctrineChoiceLoader) {
             if ($doctrineChoiceLoader) {
                 return new AjaxDoctrineChoiceLoader($doctrineChoiceLoader);
             }

--- a/Form/Type/EntityAjaxType.php
+++ b/Form/Type/EntityAjaxType.php
@@ -76,7 +76,6 @@ class EntityAjaxType extends AbstractType
                 return new AjaxDoctrineChoiceLoader($doctrineChoiceLoader);
             }
         });
-
         $resolver->setDefault('definition', null);
         $resolver->setDefault('class', function (Options $options, ?string $className) {
             return $className ?: $options['definition']::getEntity();


### PR DESCRIPTION
@rugbymauri as discussed:

Fixes:
- `Argument 2 passed to whatwedo\CrudBundle\Form\Type\EntityAjaxType::whatwedo\CrudBundle\Form\Type\{closure}() must be an instance of Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader, instance of Symfony\Component\Form\ChoiceList\Factory\Cache\ChoiceLoader 
`

- `Class name must be a valid object or string`