### PR TITLE
Deprecations

### DIFF
--- a/Controller/CrudController.php
+++ b/Controller/CrudController.php
@@ -524,7 +524,7 @@ class CrudController extends AbstractController implements CrudDefinitionControl
      */
     protected function getExportEntities(Request $request)
     {
-        $export = $request->query->get('export', []);
+        $export = $request->query->get('export') ?: [];
         if (isset($export['definition']) && isset($export['acronym']) && isset($export['class']) && isset($export['id'])
             && ($definition = $this->definitionManager->getDefinitionFromClass($export['definition']))
             && ($content = $definition->getContent($export['acronym']))


### PR DESCRIPTION
`Since symfony/http-foundation 5.1: Passing a non-scalar value as 2nd argument to "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, pass a scalar or null instead.`